### PR TITLE
Check promise success

### DIFF
--- a/critical-foft-preload-fallback-optional.html
+++ b/critical-foft-preload-fallback-optional.html
@@ -60,20 +60,24 @@
 			document.documentElement.className += " fonts-loaded-2";
 			return;
 		} else if( "fonts" in document ) {
-			document.fonts.load("1em LatoSubset").then(function () {
-				document.documentElement.className += " fonts-loaded-1";
+			document.fonts.load("1em LatoSubset").then(function(fres) {
+				if (fres[0].length) {
+					document.documentElement.className += " fonts-loaded-1";
 
-				Promise.all([
-					document.fonts.load("400 1em Lato"),
-					document.fonts.load("700 1em Lato"),
-					document.fonts.load("italic 1em Lato"),
-					document.fonts.load("italic 700 1em Lato")
-				]).then(function () {
-					document.documentElement.className += " fonts-loaded-2";
+					Promise.all([
+						document.fonts.load("400 1em Lato"),
+						document.fonts.load("700 1em Lato"),
+						document.fonts.load("italic 1em Lato"),
+						document.fonts.load("italic 700 1em Lato")
+					]).then(function(fmres) {
+						if (fmres.every(function(f) { return f.length; })) {
+							document.documentElement.className += " fonts-loaded-2";
 
-					// Optimization for Repeat Views
-					sessionStorage.fontsLoadedCriticalFoftPreloadFallback = true;
-				});
+							// Optimization for Repeat Views
+							sessionStorage.fontsLoadedCriticalFoftPreloadFallback = true;
+						}
+					});
+				}
 			});
 		} else {
 			// use fallback


### PR DESCRIPTION
Check the promise for the presence of the FontFace definitions.

 - In the event that the `@font-face` definitions are moved e.g. to an external CSS file or after the <script> tag, ensure that don't set the 'fonts-loaded' classes incorrectly

It would be up to the website author to create a new `document.fonts.load` at a later point in the page load life cycle.